### PR TITLE
Add bold italic style for /me actions

### DIFF
--- a/Campfire.AdiumMessageStyle/Contents/Resources/Footer.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Footer.html
@@ -9,7 +9,7 @@ function doMagicLinks()
         var anchor = anchors.item(i);
 
         // Match images
-        if(anchor.href.match(/\.(png|jpg|jpeg|gif)$/ig))
+        if(anchor.href.match(/\.(png|jpg|jpeg|gif)$/ig) || anchor.href.match(/\.(png\??|jpg\??|jpeg\??|gif\??)/ig))
             anchor.onclick = getImgF(anchor);
 
         // Match videos

--- a/Campfire.AdiumMessageStyle/Contents/Resources/Footer.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Footer.html
@@ -1,0 +1,103 @@
+<script type="text/javascript">
+//<![CDATA[
+
+function doMagicLinks()
+{
+    var anchors = document.getElementById("insert").parentNode.parentNode.getElementsByTagName("a");
+    for(var i = 0; i < anchors.length; i++)
+    {
+        var anchor = anchors.item(i);
+
+        // Match images
+        if(anchor.href.match(/\.(png|jpg|jpeg|gif)$/ig))
+            anchor.onclick = getImgF(anchor);
+
+        // Match videos
+        else if(anchor.href.match(/\.(mov)$/ig))
+            anchor.onclick = getVideoF(anchor);
+    }
+}
+
+function getImgF(aElm)
+{
+    return function() { if(window.event.shiftKey) return true; inlineImg(aElm); return false; };
+}
+
+function inlineImg(node)
+{
+    var img = document.createElement("img");
+    img.src = node.href;
+    img.setAttribute("txt", node.innerHTML);
+    img.setAttribute("class", "inlineImg");
+    img.style.maxHeight = "350px";
+    img.style.display = "block";
+    node.parentNode.replaceChild(img, node);
+    img.onclick = function() { revertLink(img); return false; };
+}
+
+function revertLink(node)
+{
+    var a = document.createElement("a");
+    a.href = node.src;
+    a.innerHTML = node.getAttribute("txt");
+    node.parentNode.replaceChild(a, node);
+    a.onclick = function() { if(window.event.shiftKey) return true; inlineImg(a); return false; };
+}
+
+function getVideoF(aElm)
+{
+    return function() { if(window.event.shiftKey) return true; inlineVideo(aElm); return false; };
+}
+
+function inlineVideo(node)
+{
+    var vwrap = document.createElement("div");
+    vwrap.setAttribute("class", "inlineVideo");
+    vwrap.setAttribute("src", node.href);
+    vwrap.setAttribute("txt", node.innerHTML);
+
+    var vid = document.createElement("video");
+    vid.setAttribute("controls", "controls");
+    vid.setAttribute("autoplay", "autoplay");
+    vid.width = window.innerWidth * 0.8;
+    vid.src = node.href;
+    vwrap.appendChild(vid);
+    vwrap.appendChild(document.createElement("br"));
+
+    var close = document.createElement("a");
+    close.href = "#";
+    close.innerHTML = "(Close)";
+    close.onclick = function() { revertVideo(vwrap); return false; };
+    vwrap.appendChild(close);
+
+    node.parentNode.replaceChild(vwrap, node);
+}
+
+function revertVideo(node)
+{
+    var a = document.createElement("a");
+    a.href = node.getAttribute("src");
+    a.innerHTML = node.getAttribute("txt");
+    node.parentNode.replaceChild(a, node);
+    a.onclick = function() { if(window.event.shiftKey) return true; inlineVideo(a); return false; };
+}
+
+var aM = appendMessage;
+var aNM = appendNextMessage;
+
+appendMessage = function(html)
+{
+    aM(html);
+    setTimeout(function() { doMagicLinks(); }, 80);
+}
+
+appendNextMessage = function(html)
+{
+    aNM(html);
+    setTimeout(function() { doMagicLinks(); }, 80);
+}
+
+setTimeout(function() { doMagicLinks(); }, 300);
+
+//]]>
+</script>

--- a/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/Content.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/Content.html
@@ -1,4 +1,4 @@
-<div class="container incoming initial">
+<div class="container incoming initial %messageClasses%">
 	<span class="sender">
 		%sender%
 	</span>

--- a/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/Context.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/Context.html
@@ -1,4 +1,4 @@
-<div class="container incoming initial context">
+<div class="container incoming initial context %messageClasses%">
 	<span class="sender greyed">
 		%sender%
 	</span>

--- a/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/NextContent.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/NextContent.html
@@ -1,4 +1,4 @@
-<div class="container incoming next">
+<div class="container incoming next %messageClasses%">
 	<span class="sender next">
 
 	</span>

--- a/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/NextContext.html
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/Incoming/NextContext.html
@@ -1,4 +1,4 @@
-<div class="container next incoming context">
+<div class="container next incoming context %messageClasses%">
 	<span class="sender next greyed">
 
 	</span>

--- a/Campfire.AdiumMessageStyle/Contents/Resources/main.css
+++ b/Campfire.AdiumMessageStyle/Contents/Resources/main.css
@@ -132,6 +132,18 @@ div.container .message .time
 	background-color: #efefef;
 }
 
+.container .actionMessageBody
+{
+	font-style: italic;
+	font-weight: bold;
+	color: #666;
+}
+
+.container .actionMessageBody::before, .container .actionMessageBody::after
+{
+	content: "";
+}
+
 .container.next .message, .container.initial .message
 {
 	padding-top: 3px;

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This support is mostly based on code from [the ArsTechnica message style](http:/
 
 [Download the latest version here](https://github.com/cdzombak/campfire-adium-message-style/zipball/master), extract that archive, and copy `Campfire.AdiumMessageStyle` into `~/Library/Application Support/Adium 2.0/Message Styles`.
 
-(Some command like `cp -r Campfire.AdiumMessageStyle ~/Library/Application\ Support/Adium\ 2.0/Message\ Styles` will do.)
+(Some command like `cp -r Campfire.AdiumMessageStyle ~/Library/Application\ Support/Adium\ 2.0/Message\ Styles/` will do.)
 
 Restart Adium. Open the preferences (hit `⌘,`) and do this:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# cdzombak's Campfire Adium message style
+
+Objectively the best Adium theme.
+
+## This branch
+
+[watsonian's original version](https://github.com/watsonian/campfire-adium-message-style) provides a clean, attractive, stolen-from-Campfire look that integrates nicely into your environment.
+
+Atop that, [my version](https://github.com/cdzombak/campfire-adium-message-style) adds:
+
+* a distinct style for `/me` actions
+* inline image support (see below)
+* this README
+
+## Inline image support
+
+Click a link ending in `.png` `.jpg` `.jpeg` or `.gif` to open the image inline, with a maximum height of 350 px. Click the image again to revert it to a link.
+
+Shift+click the link to open it normally in your browser.
+
+Inline movies (links ending in `.mov`) may work too, but I haven't tested it much.
+
+This support is mostly based on code from [the ArsTechnica message style](http://adiumxtras.com/index.php?a=xtras&xtra_id=7338).
+
+## Installing
+
+[Download the latest version here](https://github.com/cdzombak/campfire-adium-message-style/zipball/master), extract that archive, and copy `Campfire.AdiumMessageStyle` into `~/Library/Application Support/Adium 2.0/Message Styles`.
+
+(Some command like `cp -r Campfire.AdiumMessageStyle ~/Library/Application\ Support/Adium\ 2.0/Message\ Styles` will do.)
+
+Restart Adium. Open the preferences (hit `⌘,`) and do this:
+
+![](http://f.cl.ly/items/2N3E0M003q1o1Q2K3j2o/adiumprefs.png)


### PR DESCRIPTION
This better distinguishes actions from chat messages than the current method (surrounding the action text with apostrophes).
